### PR TITLE
Support HTTP methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "af"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Ridwan Hoq <ridhoq@users.noreply.github.com>"]
 edition = "2018"
 description = "A (http) fetch CLI 😀👍🏽"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "af"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Ridwan Hoq <ridhoq@users.noreply.github.com>"]
 edition = "2018"
 description = "A (http) fetch CLI 😀👍🏽"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/ridhoq/af"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+http = "0.2.2"
 hyper = { version = "0.14", features = ["full"] }
 hyper-tls = "0.5.0"
 structopt = "0.3.21"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,26 @@
-use hyper::{body::HttpBody as _, Client, http::Uri};
+use hyper::{body::HttpBody as _, Client};
+use http::{Method, Uri, method::InvalidMethod};
 use hyper_tls::HttpsConnector;
 use structopt::StructOpt;
 use tokio::io::{self, AsyncWriteExt as _};
 
+fn parse_method(src: &str) -> Result<Method, InvalidMethod> {
+    Method::from_bytes(src.as_bytes())
+}
+
 #[derive(StructOpt)]
+/// A (http) fetch CLI 😀👍
 struct Cli {
-    // The URI to fetch
-    uri: Uri
+    /// HTTP method
+    #[structopt(parse(try_from_str = parse_method))]
+    method: Option<Method>,
+    /// The URI to fetch
+    #[structopt()]
+    uri: Uri,
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>>{
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Cli::from_args();
 
     // Set up the HTTPS connector with the client

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,33 +1,68 @@
-use hyper::{body::HttpBody as _, Client};
-use http::{Method, Uri, method::InvalidMethod};
+use std::error;
+use std::fmt;
+
+use http::{Method, Uri};
+use hyper::{body::HttpBody as _, Client, Request};
 use hyper_tls::HttpsConnector;
+use structopt::clap::AppSettings;
 use structopt::StructOpt;
 use tokio::io::{self, AsyncWriteExt as _};
 
-fn parse_method(src: &str) -> Result<Method, InvalidMethod> {
-    Method::from_bytes(src.as_bytes())
+#[derive(Debug, Clone)]
+struct InvalidHttpMethodError;
+
+impl fmt::Display for InvalidHttpMethodError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "invalid or unknown HTTP Method")
+    }
 }
 
-#[derive(StructOpt)]
+/// Parse HTTP method from string. Throws error if invalid/unknown HTTP method
+fn parse_method(src: &str) -> Result<Method, InvalidHttpMethodError> {
+    match src.to_uppercase().as_str() {
+        "GET" => Ok(Method::GET),
+        "PUT" => Ok(Method::PUT),
+        "POST" => Ok(Method::POST),
+        "HEAD" => Ok(Method::HEAD),
+        "PATCH" => Ok(Method::PATCH),
+        "TRACE" => Ok(Method::TRACE),
+        "DELETE" => Ok(Method::DELETE),
+        "OPTIONS" => Ok(Method::OPTIONS),
+        "CONNECT" => Ok(Method::CONNECT),
+        _ => Err(InvalidHttpMethodError),
+    }
+}
+
+#[derive(StructOpt, Debug)]
+#[structopt(setting = AppSettings::AllowMissingPositional)]
 /// A (http) fetch CLI 😀👍
 struct Cli {
-    /// HTTP method
-    #[structopt(parse(try_from_str = parse_method))]
-    method: Option<Method>,
-    /// The URI to fetch
-    #[structopt()]
+    /// HTTP method. If no HTTP method is provided, GET is used by default
+    #[structopt(name = "METHOD", index = 1, default_value = "GET", parse(try_from_str = parse_method))]
+    method: Method,
+
+    /// URI to fetch
+    #[structopt(name = "URI", index = 2, required = true, parse(try_from_str))]
     uri: Uri,
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn error::Error>> {
     let args = Cli::from_args();
 
     // Set up the HTTPS connector with the client
     let https = HttpsConnector::new();
     let client = Client::builder().build::<_, hyper::Body>(https);
 
-    let mut res = client.get(args.uri).await?;
+    let req = Request::builder()
+        .method(args.method)
+        .uri(args.uri)
+        // TODO: couldn't figure out how to not pass a body with the Request::builder
+        // TODO: pass in a real body when doing POST/PUT/etc
+        .body(hyper::Body::from(""))
+        .unwrap();
+
+    let mut res = client.request(req).await?;
 
     println!("Response: {}", res.status());
     println!("Headers: {:#?}\n", res.headers());
@@ -40,4 +75,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn test_valid_http_method() {
+        let get_lower = "get";
+        let get_upper = "GET";
+
+        assert_eq!(parse_method(get_lower).unwrap(), Method::GET);
+        assert_eq!(parse_method(get_upper).unwrap(), Method::GET);
+    }
+
+    #[test]
+    fn test_invalid_http_method() {
+        let poop = "poop";
+        let empty = "";
+
+        assert!(parse_method(poop).is_err());
+        assert!(parse_method(empty).is_err());
+    }
 }


### PR DESCRIPTION
Adds optional argument for HTTP method. If one isn't passed, `GET` is used by default.

`af POST https://google.com` <-- POST google.com
`af https://google.com` <-- GET google.com

I had a lot of issues trying to support this optional argument. The author of `ht` opened this issue: https://github.com/clap-rs/clap/issues/2122 which shows what I was trying to do. They ended up working around it as seen [here](https://github.com/ducaale/ht/blob/master/src/cli.rs#L105). For now, I decided to use [AllowMissingPositional](https://docs.rs/clap/2.33.3/clap/enum.AppSettings.html#variant.AllowMissingPositional), but we'll see if that changes.

However, there is a bug when using `AllowMissingPositional` (https://github.com/clap-rs/clap/issues/1737) causes my usage message to look like this:
```
af 0.0.3
A (http) fetch CLI 😀👍

USAGE:
    af <URI> [METHOD]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

ARGS:
    <METHOD>    HTTP method. If no HTTP method is provided, GET is used by default [default: GET]
    <URI>       URI to fetch
```

The `URI` and `METHOD` args are swapped 🤦🏽 I'm prolly gonna have to hack around this somehow or take a stab at fixing it upstream. 


Closes #1