### PR TITLE
Fix body

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "af"
-version = "0.0.6"
+version = "0.0.7"
 authors = ["Ridwan Hoq <ridhoq@users.noreply.github.com>"]
 edition = "2018"
 description = "A (http) fetch CLI 😀👍🏽"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "af"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["Ridwan Hoq <ridhoq@users.noreply.github.com>"]
 edition = "2018"
 description = "A (http) fetch CLI 😀👍🏽"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "af"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["Ridwan Hoq <ridhoq@users.noreply.github.com>"]
 edition = "2018"
 description = "A (http) fetch CLI 😀👍🏽"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,14 +29,14 @@ fn parse_method(src: &str) -> Result<Method, InvalidHttpMethodError> {
 }
 
 #[derive(Clap, Debug)]
-#[clap(setting = AppSettings::AllowMissingPositional)]
+#[clap(version = clap::crate_version!(), setting = AppSettings::AllowMissingPositional)]
 /// A (http) fetch CLI 😀👍
 pub struct Opts {
     /// HTTP method. If no HTTP method is provided, GET is used by default
     #[clap(name = "METHOD", index = 1, default_value = "GET", parse(try_from_str = parse_method))]
     pub method: Method,
 
-    /// URI to fetch
+    /// URL to fetch
     #[clap(name = "URL", index = 2, required = true, parse(try_from_str))]
     pub url: Url,
 }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use reqwest::redirect::Policy;
-use reqwest::{Client};
+use reqwest::{Client, Method};
 use tokio::io::{self, AsyncWriteExt as _};
 
 use crate::cli::Opts;
@@ -17,7 +17,15 @@ pub async fn fetch(args: Opts) -> Result<()> {
         .redirect(Policy::none())
         .build()?;
 
-    let req = client.request(args.method, &args.url.to_string()).body(" ");
+    // TODO: improve body handling
+    let mut body = "";
+    if args.method == Method::POST || args.method == Method::PUT {
+        body = " ";
+    }
+
+    let req = client
+        .request(args.method, &args.url.to_string())
+        .body(body);
 
     let mut res = req.send().await?;
 


### PR DESCRIPTION
Naively handle sending a body to get around 411/malformed request issues. Will be further addressed on #3 